### PR TITLE
Updates around forward references

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,12 @@
 name: Test from-dict
 
-on: [push]
+on: 
+  # Triggers the workflow on push or pull request events
+  push:
+  pull_request:
+  
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
   build:
@@ -8,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/from_dict/_from_dict.py
+++ b/from_dict/_from_dict.py
@@ -1,6 +1,7 @@
 import sys
 import typing
-from typing import Type, TypeVar, Optional, Mapping
+import functools
+from typing import Type, TypeVar, Optional, Mapping, Union, Callable
 
 PYTHON_VERSION = sys.version_info[:2]
 IS_GE_PYTHON38 = PYTHON_VERSION >= (3, 8)  # Support for typing.get_args and typing.get_origin
@@ -79,18 +80,45 @@ def type_check(v, t) -> None:
             type_check(element, targ)
 
 
-def get_constructor_type_hints(cls: Optional[Type]) -> Optional[Mapping[str, Type]]:
+def get_constructor_type_hints(
+        cls: Optional[Type], 
+        global_ns: Optional[dict]=None, 
+        local_ns: Optional[dict]=None
+) -> Optional[Mapping[str, Type]]:
     if cls is None:
         return None
 
-    return typing.get_type_hints(cls.__init__) or typing.get_type_hints(cls)
+    return typing.get_type_hints(cls.__init__, global_ns, local_ns) or typing.get_type_hints(cls, global_ns, local_ns)
 
+
+def resolve_str_forward_ref(
+    type_or_name: Union[str, Type], 
+    cls: Type,
+    global_ns: Optional[dict]=None, 
+    local_ns: Optional[dict]=None
+) -> Type:
+    """starting in Python 3.9 types can be list['class-forward-reference'].
+    The inner string is not resolved like when typing.List['class-forward-reference'] is used. 
+    This helper will attempt to resolve these string forward references.
+    """
+    if isinstance(type_or_name, str):
+        if local_ns and type_or_name in local_ns:
+            return local_ns[type_or_name]
+        elif global_ns and type_or_name in global_ns:
+            return global_ns[type_or_name]
+        elif hasattr(sys.modules[cls.__module__], type_or_name):
+            return getattr(sys.modules[cls.__module__], type_or_name)
+        else:
+            raise TypeError(f"Type hint '{type_or_name}' could not be resolved")
+    return type_or_name
 
 def from_dict(
         cls: Type[C],
         fd_from: Optional[dict] = None,
         fd_check_types: bool = False,
         fd_copy_unknown: bool = True,
+        fd_global_ns: Optional[dict] = None,
+        fd_local_ns: Optional[dict] = None,
         **overwrite_kwargs: Optional[dict]
 ) -> C:
     """Instantiate a class with parameters given by a dict.
@@ -110,7 +138,12 @@ def from_dict(
     :param overwrite_kwargs: All additional keys will overwrite whatever is given in the dictionary.
     :return: Object of cls constructed with keys extracted from fd_from.
     """
-    cls_constructor_argument_types = get_constructor_type_hints(cls)
+
+    _get_constructor_type_hints = functools.partial(get_constructor_type_hints, global_ns=fd_global_ns, local_ns=fd_local_ns)
+    _resolve_str_forward_ref = functools.partial(resolve_str_forward_ref, cls=cls, global_ns=fd_global_ns, local_ns=fd_local_ns)
+    _from_dict = functools.partial(from_dict, fd_check_types=fd_check_types, fd_global_ns=fd_global_ns, fd_local_ns=fd_local_ns)
+
+    cls_constructor_argument_types = _get_constructor_type_hints(cls)
     if not cls_constructor_argument_types:
         raise TypeError(f"Given class {cls} is not supported by from_dict")
 
@@ -133,39 +166,22 @@ def from_dict(
         except KeyError:
             continue
 
-        # Recursively from_dict attributes which are structures, too
-        if (isinstance(given_argument, dict)
-                and get_origin(cls_argument_type) in (dict, typing.Dict)  # in Python36, origin is Dict not dict
-                and get_constructor_type_hints(get_args(cls_argument_type)[1])):
-            # Dict[a,b]; we only support b being a structure.
-            try:
-                key_type, value_type = get_args(cls_argument_type)
-                if fd_check_types:  # Perform type check on keys
-                    all(type_check(k, key_type) for k in given_argument.keys())
-                argument_value = {
-                    k: from_dict(value_type, v, fd_check_types=fd_check_types)
-                    for k, v in given_argument.items()
-                }
-            except FromDictTypeError as e:
-                # Add location for better error message
-                raise FromDictTypeError([cls_argument_name] + e.location, e.expected_type, e.found_type)
-        elif isinstance(given_argument, dict) and get_constructor_type_hints(cls_argument_type):
-            try:
-                argument_value = from_dict(cls_argument_type, given_argument, fd_check_types=fd_check_types)
-            except FromDictTypeError as e:
-                # Add location for better error message
-                raise FromDictTypeError([cls_argument_name] + e.location, e.expected_type, e.found_type)
-        elif (isinstance(given_argument, list)
-              and get_origin(cls_argument_type) in (list, typing.List)  # in Python36, origin is List not list
-              and get_constructor_type_hints(get_args(cls_argument_type)[0])):
-            try:
-                list_var_type = get_args(cls_argument_type)[0]
-                argument_value = [from_dict(list_var_type, x, fd_check_types=fd_check_types) for x in given_argument]
-            except FromDictTypeError as e:
-                # Add location for better error message
-                raise FromDictTypeError([cls_argument_name] + e.location, e.expected_type, e.found_type)
-        else:
-            argument_value = given_argument
+        cls_arg_type_args = get_args(cls_argument_type)
+        try:
+            # Recursively from_dict attributes which are structures, too
+            if isinstance(given_argument, dict):
+                argument_value = handle_dict_argument(fd_check_types, _get_constructor_type_hints, _from_dict, 
+                                                      cls_argument_type, given_argument, cls_arg_type_args)
+            elif (isinstance(given_argument, list)
+                and get_origin(cls_argument_type) in (list, typing.List)  # in Python36, origin is List not list
+                and _get_constructor_type_hints(_resolve_str_forward_ref(cls_arg_type_args[0]))):
+                list_var_type = _resolve_str_forward_ref(cls_arg_type_args[0])
+                argument_value = [_from_dict(list_var_type, x) for x in given_argument]
+            else:
+                argument_value = given_argument
+        except FromDictTypeError as e:
+            # Add location for better error message
+            raise FromDictTypeError([cls_argument_name] + e.location, e.expected_type, e.found_type)
 
         if fd_check_types:
             try:
@@ -188,3 +204,45 @@ def from_dict(
                 created_object.__dict__[arg] = val
 
     return created_object
+
+def handle_dict_argument(
+    fd_check_types: bool, 
+    _get_constructor_type_hints: Callable[[Type], Optional[Mapping[str, Type]]], 
+    _from_dict: Callable[[Type[C], dict], C], 
+    cls_argument_type: Type, 
+    given_argument: dict, 
+    cls_arg_type_args
+) -> object:
+    cls_argument_origin =  get_origin(cls_argument_type)
+    if ( cls_argument_origin in (dict, typing.Dict)  # in Python36, origin is Dict not dict
+        and _get_constructor_type_hints(cls_arg_type_args[1])):
+        # Dict[a,b]; we only support b being a structure.
+        key_type, value_type = cls_arg_type_args
+        if fd_check_types:  # Perform type check on keys
+            all(type_check(k, key_type) for k in given_argument.keys())
+        argument_value = {
+            k: _from_dict(value_type, v)
+            for k, v in given_argument.items()
+        }
+    elif cls_argument_origin == Union:
+        if (len(cls_arg_type_args) == 2 and cls_arg_type_args[1] == type(None) # Optional
+            and _get_constructor_type_hints(cls_arg_type_args[0])):
+            argument_value = _from_dict(cls_arg_type_args[0], given_argument)
+        else:
+            argument_value = given_argument
+            for arg_type in cls_arg_type_args:
+                if arg_type == type(None):
+                    continue
+                required_keys = {k for k in _get_constructor_type_hints(arg_type)}
+                required_keys.discard("return")
+                if all(k in required_keys for k in given_argument):
+                    try:
+                        argument_value = _from_dict(arg_type, given_argument)
+                        break
+                    except TypeError:
+                        pass
+    elif _get_constructor_type_hints(cls_argument_type):
+        argument_value = _from_dict(cls_argument_type, given_argument)
+    else:
+        argument_value = given_argument
+    return argument_value

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="from-dict",
-    version="0.2.0",
+    version="0.2.1",
     packages=find_packages(),
     author="Wanja Chresta",
     author_email="wanja.hs@chrummibei.ch",

--- a/tests/test_generics_with_dataclasses.py
+++ b/tests/test_generics_with_dataclasses.py
@@ -1,0 +1,142 @@
+from typing import Optional, Union
+
+import sys
+import pytest
+
+from from_dict import from_dict, FromDictTypeError
+
+if sys.version_info[:2] >= (3, 7):
+    from dataclasses import dataclass
+else:
+    from attr import dataclass
+
+
+@dataclass(frozen=True)
+class SimpleNode:
+    name: str
+    value: str
+
+
+@dataclass(frozen=True)
+class SimpleNode2:
+    name: str
+    reference: str
+
+@dataclass(frozen=True)
+class NodeWithOptional:
+    node1: SimpleNode
+    node2: Optional[SimpleNode]
+    node3: Optional[SimpleNode] = None
+
+
+@dataclass(frozen=True)
+class NodeWithUnion:
+    node: Union[SimpleNode, SimpleNode2]
+
+@dataclass(frozen=True)
+class NodeWithUnionWithBuiltInType:
+    node: Union[SimpleNode, str]
+
+def test_optional():
+    data = {
+        "node1": {"name": "n1", "value": "v1"},
+        "node2": {"name": "n2", "value": "v2"},
+        "node3": {"name": "n3", "value": "v3"},
+     }
+    node = from_dict(NodeWithOptional, data, fd_check_types=True)
+    assert node.node1.name == "n1"
+    assert node.node1.value == "v1"
+    assert node.node2.name == "n2"
+    assert node.node2.value == "v2"
+    assert node.node3.name == "n3"
+    assert node.node3.value == "v3"
+    
+    data = {
+        "node1": {"name": "n1", "value": "v1"},
+        "node2": {"name": "n2", "value": "v2"}
+     }
+    node = from_dict(NodeWithOptional, data, fd_check_types=True)
+    assert node.node1.name == "n1"
+    assert node.node1.value == "v1"
+    assert node.node2.name == "n2"
+    assert node.node2.value == "v2"
+    assert node.node3 == None
+    
+    data = {
+        "node1": {"name": "n1", "value": "v1"},
+        "node2": None
+     }
+    node = from_dict(NodeWithOptional, data, fd_check_types=True)
+    assert node.node1.name == "n1"
+    assert node.node1.value == "v1"
+    assert node.node2 == None
+    assert node.node3 == None
+    data = {
+        "node1": {"name": "n1", "value": "v1"},
+        "node2": None,
+        "node3": None
+     }
+    node = from_dict(NodeWithOptional, data, fd_check_types=True)
+    assert node.node1.name == "n1"
+    assert node.node1.value == "v1"
+    assert node.node2 == None
+    assert node.node3 == None
+    
+    data = {"node1": {"name": "n1", "value": "v1"}}
+    with pytest.raises(TypeError) as e:
+        node = from_dict(NodeWithOptional, data, fd_check_types=True)
+    assert "missing 1 required positional argument: 'node2'" in str(e.value)
+
+
+def test_union():
+    data = {  "node": {"name": "n1", "value": "v1"} }
+    node = from_dict(NodeWithUnion, data, fd_check_types=True)
+    assert isinstance(node.node, SimpleNode)
+    assert node.node.name == "n1"
+    assert node.node.value == "v1"
+
+    data = {  "node": {"name": "n1", "reference": "node-X"} }
+    node = from_dict(NodeWithUnion, data, fd_check_types=True)
+    assert isinstance(node.node, SimpleNode2)
+    assert node.node.name == "n1"
+    assert node.node.reference == "node-X"
+
+    data = {  "node": {"name": "n1", "no_match": "node-X"} }
+    node = from_dict(NodeWithUnion, data)
+    assert isinstance(node.node, dict)
+    assert node.node["name"] == "n1"
+    assert node.node["no_match"] == "node-X"
+    
+    data = {  "node": {"name": "n1", "no_match": "node-X"} }
+    with pytest.raises(TypeError) as e:
+        node = from_dict(NodeWithUnion, data, fd_check_types=True)
+    assert str(e.value) == ('For "node", expected typing.Union[test_generics_with_dataclasses.SimpleNode, '
+                            'test_generics_with_dataclasses.SimpleNode2] but found <class \'dict\'>')
+
+def test_union_with_builtin_type():
+    data = {  "node": {"name": "n1", "value": "v1"} }
+    node = from_dict(NodeWithUnionWithBuiltInType, data, fd_check_types=True)
+    assert isinstance(node.node, SimpleNode)
+    assert node.node.name == "n1"
+    assert node.node.value == "v1"
+
+    data = {  "node": "Hello" }
+    node = from_dict(NodeWithUnionWithBuiltInType, data, fd_check_types=True)
+    assert isinstance(node.node, str)
+    assert node.node == "Hello"
+
+    data = {  "node": {"name": "n1", "no_match": "node-X"} }
+    node = from_dict(NodeWithUnionWithBuiltInType, data)
+    assert isinstance(node.node, dict)
+    assert node.node["name"] == "n1"
+    assert node.node["no_match"] == "node-X"
+    
+    data = {  "node": {"name": "n1", "no_match": "node-X"} }
+    with pytest.raises(FromDictTypeError) as e:
+        from_dict(NodeWithUnionWithBuiltInType, data, fd_check_types=True)
+    assert str(e.value) == 'For "node", expected typing.Union[test_generics_with_dataclasses.SimpleNode, str] but found <class \'dict\'>'
+
+    data = {  "node": 123 }
+    with pytest.raises(FromDictTypeError) as e:
+        node = from_dict(NodeWithUnionWithBuiltInType, data, fd_check_types=True)
+    assert str(e.value) == 'For "node", expected typing.Union[test_generics_with_dataclasses.SimpleNode, str] but found <class \'int\'>'

--- a/tests/test_self_references_global.py
+++ b/tests/test_self_references_global.py
@@ -1,0 +1,74 @@
+from typing import Optional, List, Dict
+
+import sys
+
+from from_dict import from_dict
+
+if sys.version_info[:2] >= (3, 7):
+    from dataclasses import dataclass
+    GLOBALS = None # Don't need globals()
+else:
+    from attr import dataclass
+    GLOBALS = globals()
+
+if sys.version_info[:2] >= (3, 9):
+    LIST = list
+else:
+    LIST = List
+
+
+@dataclass
+class LinkListNode:
+    name: str
+    next: 'LinkListNode'
+
+@dataclass
+class TreeNode:
+    name: str
+    children: LIST['TreeNode']
+
+@dataclass
+class LinkListNode2:
+    name: str
+    next: Optional['LinkListNode2'] 
+
+
+@dataclass
+class DictNode:
+    name: str
+    children: Dict[str, 'DictNode']
+
+def test_self_ref():
+    data = {"name": "n1", "next": {"name": "n2", "next": None}}
+    # Can't type check because next is not optional 
+    node = from_dict(LinkListNode, data, fd_global_ns=GLOBALS)
+    assert node.name == "n1"
+    assert node.next.name == "n2"
+
+
+def test_self_ref_in_list():
+    data = {"name": "n1", "children": [{"name": "n2", "children": []}]}
+    node = from_dict(TreeNode, data, fd_check_types=True, fd_global_ns=GLOBALS)
+    assert node.name == "n1"
+    assert node.children[0].name == "n2"
+
+
+def test_self_ref_in_optional():
+    data = {"name": "n1", "next": {"name": "n2", "next": None}}
+    node = from_dict(LinkListNode2, data, fd_check_types=True, fd_global_ns=GLOBALS)
+    assert node.name == "n1"
+    assert node.next.name == "n2"
+
+
+def test_self_ref_in_dict():
+    data = {
+        "name": "n1", 
+        "children": {
+            "id-123": {"name": "n2", "children": {}},
+            "id-456": {"name": "n3", "children": {}}
+        }
+    }
+    node = from_dict(DictNode, data, fd_check_types=True, fd_global_ns=GLOBALS)
+    assert node.name == "n1"
+    assert node.children["id-123"].name == "n2"
+    assert node.children["id-456"].name == "n3"

--- a/tests/test_self_references_local.py
+++ b/tests/test_self_references_local.py
@@ -1,0 +1,70 @@
+
+from typing import Optional, List, Dict
+
+import sys
+
+from from_dict import from_dict
+
+if sys.version_info[:2] >= (3, 7):
+    from dataclasses import dataclass
+else:
+    from attr import dataclass
+
+if sys.version_info[:2] >= (3, 9):
+    LIST = list
+else:
+    LIST = List
+
+
+def test_local_self_ref():
+    @dataclass
+    class Node:
+        name: str
+        next: 'Node'
+
+    data = {"name": "n1", "next": {"name": "n2", "next": None}}
+    node = from_dict(Node, data, fd_local_ns=locals())
+    assert node.name == "n1"
+    assert node.next.name == "n2"
+
+def test_local_self_ref_in_list():
+    @dataclass
+    class Node:
+        name: str
+        children: LIST['Node']
+
+    data = {"name": "n1", "children": [{"name": "n2", "children": []}]}
+    node = from_dict(Node, data, fd_check_types=True, fd_local_ns=locals())
+    assert node.name == "n1"
+    assert node.children[0].name == "n2"
+
+
+def test_local_self_ref_in_optional():
+    @dataclass
+    class Node:
+        name: str
+        next: Optional['Node']
+
+    data = {"name": "n1", "next": {"name": "n2", "next": None}}
+    node = from_dict(Node, data, fd_check_types=True, fd_local_ns=locals())
+    assert node.name == "n1"
+    assert node.next.name == "n2"
+
+    
+def test_local_self_ref_in_dict():
+    @dataclass
+    class Node:
+        name: str
+        children: Dict[str, 'Node']
+
+    data = {
+        "name": "n1", 
+        "children": {
+            "id-123": {"name": "n2", "children": {}},
+            "id-456": {"name": "n3", "children": {}}
+        }
+    }
+    node = from_dict(Node, data, fd_check_types=True, fd_local_ns=locals())
+    assert node.name == "n1"
+    assert node.children["id-123"].name == "n2"
+    assert node.children["id-456"].name == "n3"


### PR DESCRIPTION
- Adding support for list['forward-ref']
- Adding support for data-classes within generic types
- adding more tests
- update to when GitHub actions are run and what versions of Python are tested

This started out as just an update to support list['forward-ref'] but I have made more updates as I experimented with this package. 
I do a few things that I am not sure are considered best practices. Mainly around the use of the functools.partial(), but I think it make the code easier to follow and more maintainable. 

