### PR TITLE
Cleanup of the tests

### DIFF
--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -47,9 +47,6 @@ class InnerData:
     tags: List[str]
 
 def test_cache_speed_improvement():
-    if sys.version_info[:2] == (3, 6):
-        pytest.skip("Python 3.6 requires the use of globals(). This disabled caching.")
-    
     test_data =  {
         'name': 'root', 
         'id': 12324, 
@@ -84,7 +81,7 @@ def test_cache_speed_improvement():
     cache_enable()
     assert disabled_time > (enabled_time * 2)
 
-def _get_time_for_x_calls(test_data: str):
+def _get_time_for_x_calls(test_data: dict):
     start_time = time.time()
     LOOPS = 1_000
     for _ in range(LOOPS):

--- a/tests/test_from_dict.py
+++ b/tests/test_from_dict.py
@@ -1,17 +1,10 @@
-from typing import Optional, List, Type, NamedTuple, Union, Dict
+from dataclasses import dataclass
+from typing import Dict, List, NamedTuple, Optional, Type, Union
 
 import attr
 import pytest
-import sys
+from from_dict import FromDictTypeError, from_dict
 
-from from_dict import from_dict, FromDictTypeError
-
-if sys.version_info[:2] >= (3, 7):
-    from dataclasses import dataclass
-    GLOBALS = None # Don't need globals()
-else:
-    from attr import dataclass
-    GLOBALS = globals()
 
 @dataclass
 class Structures:
@@ -102,7 +95,7 @@ def test_packing(structures: Structures):
         }
     }
 
-    main_object = from_dict(structures.outer_structure, input_dict, fd_global_ns=GLOBALS)
+    main_object = from_dict(structures.outer_structure, input_dict)
 
     assert main_object.baz.bar == "Works :)"
     assert isinstance(main_object, structures.outer_structure)
@@ -110,18 +103,18 @@ def test_packing(structures: Structures):
 
 
 def test_keyword_style(structures: Structures):
-    m = from_dict(structures.outer_structure, foo=22, baz=structures.inner_structure(foo=42, bar="Works :)"), fd_global_ns=GLOBALS)
+    m = from_dict(structures.outer_structure, foo=22, baz=structures.inner_structure(foo=42, bar="Works :)"))
     assert m.foo == 22
     assert m.baz.foo == 42
     assert m.baz.bar == "Works :)"
 
 
 def test_keyword_style_overwrites_positional(structures: Structures):
-    assert from_dict(structures.inner_structure, {"foo": 42, "bar": "Works :)"}, foo=0, fd_global_ns=GLOBALS).foo == 0
+    assert from_dict(structures.inner_structure, {"foo": 42, "bar": "Works :)"}, foo=0).foo == 0
 
 
 def test_additional_keys_are_allowed(structures: Structures):
-    my_obj = from_dict(structures.inner_structure, foo=22, bar="Works", additional=[1, 2, 3], fd_global_ns=GLOBALS)
+    my_obj = from_dict(structures.inner_structure, foo=22, bar="Works", additional=[1, 2, 3])
     assert my_obj.foo == 22
     assert my_obj.bar == "Works"
 
@@ -160,7 +153,7 @@ def test_missing_key_discovered_in_subdict_inherent(structures: Structures):
 def test_invalid_type_discovered_in_subdict_from_dict(structures: Structures):
     with pytest.raises(FromDictTypeError) as e:
         from_dict(structures.outer_structure, {"foo": 22, "baz": {"foo": 42, "bar": ["wrong type"]}},
-                  fd_check_types=True, fd_global_ns=GLOBALS)
+                  fd_check_types=True)
 
     assert str(e.value) == "For \"baz.bar\", expected <class 'str'> but found <class 'list'>"
 
@@ -168,7 +161,7 @@ def test_invalid_type_discovered_in_subdict_from_dict(structures: Structures):
 def test_invalid_type_discovered_in_subdict(structures: Structures):
     with pytest.raises(FromDictTypeError) as e:
         from_dict(structures.outer_structure, {"foo": 22, "baz": {"foo": 42, "bar": ["wrong type"]}},
-                  fd_check_types=True, fd_global_ns=GLOBALS)
+                  fd_check_types=True)
 
     assert str(e.value) == "For \"baz.bar\", expected <class 'str'> but found <class 'list'>"
 

--- a/tests/test_generics_with_dataclasses.py
+++ b/tests/test_generics_with_dataclasses.py
@@ -1,14 +1,8 @@
+from dataclasses import dataclass
 from typing import Optional, Union
 
-import sys
 import pytest
-
-from from_dict import from_dict, FromDictTypeError
-
-if sys.version_info[:2] >= (3, 7):
-    from dataclasses import dataclass
-else:
-    from attr import dataclass
+from from_dict import FromDictTypeError, from_dict
 
 
 @dataclass(frozen=True)
@@ -46,8 +40,10 @@ def test_optional():
     node = from_dict(NodeWithOptional, data, fd_check_types=True)
     assert node.node1.name == "n1"
     assert node.node1.value == "v1"
+    assert isinstance(node.node2, SimpleNode)
     assert node.node2.name == "n2"
     assert node.node2.value == "v2"
+    assert isinstance(node.node3, SimpleNode)
     assert node.node3.name == "n3"
     assert node.node3.value == "v3"
     
@@ -58,6 +54,7 @@ def test_optional():
     node = from_dict(NodeWithOptional, data, fd_check_types=True)
     assert node.node1.name == "n1"
     assert node.node1.value == "v1"
+    assert isinstance(node.node2, SimpleNode)
     assert node.node2.name == "n2"
     assert node.node2.value == "v2"
     assert node.node3 == None
@@ -128,8 +125,8 @@ def test_union_with_builtin_type():
     data = {  "node": {"name": "n1", "no_match": "node-X"} }
     node = from_dict(NodeWithUnionWithBuiltInType, data)
     assert isinstance(node.node, dict)
-    assert node.node["name"] == "n1"
-    assert node.node["no_match"] == "node-X"
+    assert node.node["name"] == "n1"  # type: ignore
+    assert node.node["no_match"] == "node-X"  # type: ignore
     
     data = {  "node": {"name": "n1", "no_match": "node-X"} }
     with pytest.raises(FromDictTypeError) as e:

--- a/tests/test_namespaces_class.py
+++ b/tests/test_namespaces_class.py
@@ -27,12 +27,12 @@ def test_simple():
 # . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 
 def new_with_changing_locals():
-    r = os.urandom()
+    r = os.urandom(2)
     d = datetime.datetime.now()
     return _fd.NamespaceTypes(globals(), locals())
 
 
-def new_with_changing_locals():
+def test_with_changing_locals():
     obj1 = new_with_changing_locals()
     obj2 = new_with_changing_locals()
     assert (obj1 == obj2)
@@ -69,7 +69,7 @@ def new_with_nested_dataclass():
         name: str
     return _fd.NamespaceTypes(globals(), locals())
 
-def testing_with_nested_dataclass():
+def test_with_nested_dataclass():
     ''' NOTE: This test expects that the namespaces are NOT equal 
     '''
     obj1 = new_with_nested_dataclass()
@@ -91,6 +91,7 @@ def new_with_nested_global_dataclass():
 def test_with_nested_global_dataclass():
     obj1 = new_with_nested_global_dataclass()
     obj2 = new_with_nested_global_dataclass()
+    assert isinstance(obj2.local_types, dict)
     assert obj2.local_types["dc"]  == DummyClass1
     assert (obj1 == obj2)
 
@@ -103,6 +104,7 @@ def new_with_nested_module_dataclass():
 def test_with_nested_module_dataclass():
     obj1 = new_with_nested_module_dataclass()
     obj2 = new_with_nested_module_dataclass()
+    assert isinstance(obj2.local_types, dict)
     assert obj2.local_types["JSONDecoder"].__name__  == "JSONDecoder"
     assert (obj1 == obj2)
 
@@ -121,7 +123,7 @@ class DummyClass3:
 def new_with_copy_of_namespaces():
     return _fd.NamespaceTypes(globals().copy(), locals().copy())
 
-def testing_with_nested_dataclass():
+def test_with_copy_of_namespaces():
     obj1 = new_with_copy_of_namespaces()
     obj2 = new_with_copy_of_namespaces()
     assert (obj1 == obj2)

--- a/tests/test_readme_example.py
+++ b/tests/test_readme_example.py
@@ -1,10 +1,6 @@
-import sys
-
-if sys.version_info[:2] >= (3, 7):
-    from dataclasses import dataclass
-else:
-    from attr import dataclass
+from dataclasses import dataclass
 from typing import List, Optional
+
 from from_dict import from_dict
 
 

--- a/tests/test_self_references_global.py
+++ b/tests/test_self_references_global.py
@@ -1,15 +1,8 @@
-from typing import Optional, List, Dict
-
 import sys
+from dataclasses import dataclass
+from typing import Dict, List, Optional
 
 from from_dict import from_dict
-
-if sys.version_info[:2] >= (3, 7):
-    from dataclasses import dataclass
-    GLOBALS = None # Don't need globals()
-else:
-    from attr import dataclass
-    GLOBALS = globals()
 
 if sys.version_info[:2] >= (3, 9):
     LIST = list
@@ -41,22 +34,23 @@ class DictNode:
 def test_self_ref():
     data = {"name": "n1", "next": {"name": "n2", "next": None}}
     # Can't type check because next is not optional 
-    node = from_dict(LinkListNode, data, fd_global_ns=GLOBALS)
+    node = from_dict(LinkListNode, data)
     assert node.name == "n1"
     assert node.next.name == "n2"
 
 
 def test_self_ref_in_list():
     data = {"name": "n1", "children": [{"name": "n2", "children": []}]}
-    node = from_dict(TreeNode, data, fd_check_types=True, fd_global_ns=GLOBALS)
+    node = from_dict(TreeNode, data, fd_check_types=True)
     assert node.name == "n1"
     assert node.children[0].name == "n2"
 
 
 def test_self_ref_in_optional():
     data = {"name": "n1", "next": {"name": "n2", "next": None}}
-    node = from_dict(LinkListNode2, data, fd_check_types=True, fd_global_ns=GLOBALS)
+    node = from_dict(LinkListNode2, data, fd_check_types=True)
     assert node.name == "n1"
+    assert isinstance(node.next, LinkListNode2)
     assert node.next.name == "n2"
 
 
@@ -68,7 +62,7 @@ def test_self_ref_in_dict():
             "id-456": {"name": "n3", "children": {}}
         }
     }
-    node = from_dict(DictNode, data, fd_check_types=True, fd_global_ns=GLOBALS)
+    node = from_dict(DictNode, data, fd_check_types=True)
     assert node.name == "n1"
     assert node.children["id-123"].name == "n2"
     assert node.children["id-456"].name == "n3"

--- a/tests/test_self_references_local.py
+++ b/tests/test_self_references_local.py
@@ -1,14 +1,9 @@
 
-from typing import Optional, List, Dict
-
 import sys
+from dataclasses import dataclass
+from typing import Dict, List, Optional
 
 from from_dict import from_dict
-
-if sys.version_info[:2] >= (3, 7):
-    from dataclasses import dataclass
-else:
-    from attr import dataclass
 
 if sys.version_info[:2] >= (3, 9):
     LIST = list
@@ -48,6 +43,7 @@ def test_local_self_ref_in_optional():
     data = {"name": "n1", "next": {"name": "n2", "next": None}}
     node = from_dict(Node, data, fd_check_types=True, fd_local_ns=locals())
     assert node.name == "n1"
+    assert isinstance(node.next, Node)
     assert node.next.name == "n2"
 
     


### PR DESCRIPTION
- Mostly cleanup that can be done because Python 3.6 support was dropped
- There were also some duplicate function names that were fixed.