### PR TITLE
Adding test coverage for the Python 3.12 way to defining generic classes

### DIFF
--- a/tests/_type_checking_classes.py
+++ b/tests/_type_checking_classes.py
@@ -1,0 +1,60 @@
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Union, TypeVar, Generic, Literal
+
+import attr
+
+# . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+# Classes used by the tests
+
+class NormalClass:
+    def __init__(self, v: str) -> None:
+        self.value = v
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, NormalClass) and self.value == other.value
+
+
+@dataclass(frozen=True)
+class DataClass:
+    field: str
+
+
+@attr.s(auto_attribs=True)
+class AttrClass:
+    attrib: str
+
+TTestType = TypeVar("TTestType")
+TSelfRef = TypeVar("TSelfRef")
+
+@dataclass
+class ClassBase(Generic[TTestType, TSelfRef]):
+    normal: TTestType
+    optional: Optional[TTestType]
+    union: Union[str, NormalClass, DataClass, TTestType]
+    any: Any
+    self_ref: Optional[TSelfRef]
+
+    list_normal: List[TTestType]
+    list_optional: List[Optional[TTestType]]
+    list_union: List[Union[str, NormalClass, DataClass, TTestType]]
+    list_any: List[Any]
+    list_self_ref: List[TSelfRef]
+    
+    dict_normal: Dict[str, TTestType]
+    dict_optional: Dict[str, Optional[TTestType]]
+    dict_union: Dict[str, Union[str, NormalClass, DataClass, TTestType]]
+    dict_any: Dict[str, Any]
+    dict_self_ref: Dict[str, TSelfRef]
+
+
+ClassPrimitives = ClassBase[int, "ClassPrimitives"]
+ClassDict = ClassBase[Dict[str,str], "ClassDict"]
+ClassDictSimple = ClassBase[dict, "ClassDictSimple"]
+ClassList = ClassBase[List[str], "ClassList"]
+ClassDataClass = ClassBase[DataClass, "ClassDataClass"]
+ClassNormalClass = ClassBase[NormalClass, "ClassNormalClass"]
+ClassAttrClass = ClassBase[AttrClass, "ClassAttrClass"]
+ClassListDataClass = ClassBase[List[DataClass], "ClassListDataClass"]
+ClassDictDataClass = ClassBase[Dict[str, DataClass], "ClassDictDataClass"]
+ClassLiteral = ClassBase[Literal["my-literal"], "ClassLiteral"]
+ClassMultiLiteral = ClassBase[Literal[2, 3, 5, 7, 11], "ClassMultiLiteral"]

--- a/tests/_type_checking_classes_py312.py
+++ b/tests/_type_checking_classes_py312.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+from typing import Any, Optional, Literal
+
+
+from _type_checking_classes import DataClass, NormalClass, AttrClass
+
+@dataclass
+class ClassBase[TTestType, TSelfRef]:
+    normal: TTestType
+    optional: Optional[TTestType]
+    union: str | NormalClass | DataClass | TTestType
+    any: Any
+    self_ref: Optional[TSelfRef]
+
+    list_normal: list[TTestType]
+    list_optional: list[Optional[TTestType]]
+    list_union: list[str | NormalClass | DataClass | TTestType]
+    list_any: list[Any]
+    list_self_ref: list[TSelfRef]
+    
+    dict_normal: dict[str, TTestType]
+    dict_optional: dict[str, Optional[TTestType]]
+    dict_union: dict[str, str | NormalClass | DataClass | TTestType]
+    dict_any: dict[str, Any]
+    dict_self_ref: dict[str, TSelfRef]
+
+
+ClassPrimitives = ClassBase[int, "ClassPrimitives"]
+ClassDict = ClassBase[dict[str,str], "ClassDict"]
+ClassDictSimple = ClassBase[dict, "ClassDictSimple"]
+ClassList = ClassBase[list[str], "ClassList"]
+ClassDataClass = ClassBase[DataClass, "ClassDataClass"]
+ClassNormalClass = ClassBase[NormalClass, "ClassNormalClass"]
+ClassAttrClass = ClassBase[AttrClass, "ClassAttrClass"]
+ClassListDataClass = ClassBase[list[DataClass], "ClassListDataClass"]
+ClassDictDataClass = ClassBase[dict[str, DataClass], "ClassDictDataClass"]
+ClassLiteral = ClassBase[Literal["my-literal"], "ClassLiteral"]
+ClassMultiLiteral = ClassBase[Literal[2, 3, 5, 7, 11], "ClassMultiLiteral"]

--- a/tests/test_type_checking.py
+++ b/tests/test_type_checking.py
@@ -1,69 +1,34 @@
+import sys
 import copy
 import datetime
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Union, Type, Callable, TypeVar, Generic, Literal
+from typing import Type, Callable
 
 from from_dict import FromDictTypeError, from_dict
 
-import attr
 import pytest
 
 # . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 # Classes used by the tests
 
-class NormalClass:
-    def __init__(self, v: str) -> None:
-        self.value = v
+if sys.version_info[0:1] < (3, 12):
+    from _type_checking_classes import (
+        NormalClass, DataClass, AttrClass,
+        ClassPrimitives, ClassDict, ClassDictSimple,
+        ClassList, ClassDataClass, ClassNormalClass,
+        ClassAttrClass, ClassListDataClass, ClassDictDataClass,
+        ClassLiteral, ClassMultiLiteral
+    )
+else:
+    from _type_checking_classes_py312 import (
+        NormalClass, DataClass, AttrClass,
+        ClassPrimitives, ClassDict, ClassDictSimple,
+        ClassList, ClassDataClass, ClassNormalClass,
+        ClassAttrClass, ClassListDataClass, ClassDictDataClass,
+        ClassLiteral, ClassMultiLiteral
+    )
 
-    def __eq__(self, other: object) -> bool:
-        return isinstance(other, NormalClass) and self.value == other.value
-
-
-@dataclass(frozen=True)
-class DataClass:
-    field: str
-
-
-@attr.s(auto_attribs=True)
-class AttrClass:
-    attrib: str
-
-TTestType = TypeVar("TTestType")
-TSelfRef = TypeVar("TSelfRef")
-
-@dataclass
-class ClassBase(Generic[TTestType, TSelfRef]):
-    normal: TTestType
-    optional: Optional[TTestType]
-    union: Union[str, NormalClass, DataClass, TTestType]
-    any: Any
-    self_ref: Optional[TSelfRef]
-
-    list_normal: List[TTestType]
-    list_optional: List[Optional[TTestType]]
-    list_union: List[Union[str, NormalClass, DataClass, TTestType]]
-    list_any: List[Any]
-    list_self_ref: List[TSelfRef]
-    
-    dict_normal: Dict[str, TTestType]
-    dict_optional: Dict[str, Optional[TTestType]]
-    dict_union: Dict[str, Union[str, NormalClass, DataClass, TTestType]]
-    dict_any: Dict[str, Any]
-    dict_self_ref: Dict[str, TSelfRef]
-
-
-ClassPrimitives = ClassBase[int, "ClassPrimitives"]
-ClassDict = ClassBase[Dict[str,str], "ClassDict"]
-ClassDictSimple = ClassBase[dict, "ClassDictSimple"]
-ClassList = ClassBase[List[str], "ClassList"]
-ClassDataClass = ClassBase[DataClass, "ClassDataClass"]
-ClassNormalClass = ClassBase[NormalClass, "ClassNormalClass"]
-ClassAttrClass = ClassBase[AttrClass, "ClassAttrClass"]
-ClassListDataClass = ClassBase[List[DataClass], "ClassListDataClass"]
-ClassDictDataClass = ClassBase[Dict[str, DataClass], "ClassDictDataClass"]
-ClassLiteral = ClassBase[Literal["my-literal"], "ClassLiteral"]
-ClassMultiLiteral = ClassBase[Literal[2, 3, 5, 7, 11], "ClassMultiLiteral"]
 
 # . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 # helper functions


### PR DESCRIPTION
I wanted to add coverage for the [new way to defining generic classes](https://docs.python.org/3.12/reference/compound_stmts.html#generic-classes)

It also adds coverage for the not so new ways of specifying generic list, dict, and union types. 

Not sure if there is a better way to do this, but this seemed like the best approach to reduce code duplication. 