### PR TITLE
Fixing in handling generic classes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,10 @@
+# Version 0.4.2 - 2024-09-21
+* Bug fix for generic classes
+
+# Version 0.4.1 - 2014-03-07
+* Officially supporting Python 3.12
+* Fixing bug with unions and data-classes that have default values
+  
 # Version 0.4.0 - 2023-06-16
 * Adding basic support for Literal type hints
 * Adding `fd_error_on_unknown` argument

--- a/from_dict/_from_dict.py
+++ b/from_dict/_from_dict.py
@@ -355,8 +355,8 @@ def _from_dict_inner(
 
 def handle_item(
     _get_constructor_type_hints: Callable[[Type], Mapping[str, Type]],
-    _resolve_str_forward_ref,
-    _from_dict: Callable[[Type[C], dict], C],
+    _resolve_str_forward_ref: Callable[[Union[str, Type]], Type],
+    _from_dict: Callable[[Type, dict], Any],
     cls_argument_type: Type,
     given_argument: Any,
 ):
@@ -386,12 +386,12 @@ def handle_item(
 
 def handle_dict_argument(
     _get_constructor_type_hints: Callable[[Type], Mapping[str, Type]],
-    _resolve_str_forward_ref,
-    _from_dict: Callable[[Type[C], dict], C],
+    _resolve_str_forward_ref: Callable[[Union[str, Type]], Type],
+    _from_dict: Callable[[Type, dict], Any],
     cls_argument_type: Type,
     cls_arg_type_args: tuple,
     given_argument: dict,
-) -> object:
+):
     """This is called when the given argument is an instance of 'dict'"""
 
     # Empty dictionary. Does not matter what the items are.
@@ -481,12 +481,12 @@ def handle_dict_argument(
 
 def handle_list_argument(
     _get_constructor_type_hints: Callable[[Type], Mapping[str, Type]],
-    _resolve_str_forward_ref,
-    _from_dict: Callable[[Type[C], dict], C],
+    _resolve_str_forward_ref: Callable[[Union[str, Type]], Type],
+    _from_dict: Callable[[Type, dict], Any],
     cls_argument_type: Type,
     cls_arg_type_args: tuple,
     given_argument: list,
-) -> object:
+):
     """This is called when the given argument is an instance of 'list'"""
 
     # Empty list. Does not matter what the elements are.
@@ -560,8 +560,8 @@ def handle_list_argument(
 
 def _handle_union(
     _get_constructor_type_hints: Callable[[Type], Mapping[str, Type]],
-    _resolve_str_forward_ref,
-    _from_dict: Callable[[Type[C], dict], C],
+    _resolve_str_forward_ref: Callable[[Union[str, Type]], Type],
+    _from_dict: Callable[[Type, dict], Any],
     cls_argument_type: Type,
     given_argument: Any,
 ):

--- a/from_dict/_from_dict.py
+++ b/from_dict/_from_dict.py
@@ -177,12 +177,15 @@ def _resolve_generic_class(
     if origin is None and hasattr(cls, "__orig_bases__"):
         # Only support the inherit from a generic class if it is
         # the first class in the mro.
+        init_method = cls.__init__
         cls = cls.__orig_bases__[0]
         origin = get_origin(cls)
+    else:
+        init_method = origin.__init__
     args = [resolve_str_forward_ref(a, cls, ns_types) for a in get_args(cls)]
     swaps = dict(zip(getattr(origin, "__parameters__"), args))
     hints = typing.get_type_hints(
-        origin.__init__, ns_types.global_types, ns_types.local_types
+        init_method, ns_types.global_types, ns_types.local_types
     ) or typing.get_type_hints(origin, ns_types.global_types, ns_types.local_types)
     for k, v in hints.items():
         if v in swaps:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="from-dict",
-    version="0.4.1",
+    version="0.4.2",
     packages=find_packages(),
     author="Wanja Chresta",
     author_email="wanja.hs@chrummibei.ch",

--- a/tests/_type_checking_classes.py
+++ b/tests/_type_checking_classes.py
@@ -23,6 +23,16 @@ class DataClass:
 class AttrClass:
     attrib: str
 
+
+T = TypeVar("T")
+@dataclass
+class GenericDataClass(Generic[T]):
+    field: T
+
+@dataclass
+class GenericDataClassSubClass(GenericDataClass[str]):
+    another: int
+
 TTestType = TypeVar("TTestType")
 TSelfRef = TypeVar("TSelfRef")
 
@@ -58,3 +68,6 @@ ClassListDataClass = ClassBase[List[DataClass], "ClassListDataClass"]
 ClassDictDataClass = ClassBase[Dict[str, DataClass], "ClassDictDataClass"]
 ClassLiteral = ClassBase[Literal["my-literal"], "ClassLiteral"]
 ClassMultiLiteral = ClassBase[Literal[2, 3, 5, 7, 11], "ClassMultiLiteral"]
+
+ClassGenericDataClassINT = ClassBase[GenericDataClass[int], "ClassGenericDataClassINT"]
+ClassGenericDataClassSubClass = ClassBase[GenericDataClassSubClass, "ClassGenericDataClassSubClass"]

--- a/tests/_type_checking_classes_py312.py
+++ b/tests/_type_checking_classes_py312.py
@@ -5,6 +5,14 @@ from typing import Any, Optional, Literal
 from _type_checking_classes import DataClass, NormalClass, AttrClass
 
 @dataclass
+class GenericDataClass[T]:
+    field: T
+
+@dataclass
+class GenericDataClassSubClass(GenericDataClass[str]):
+    another: int
+
+@dataclass
 class ClassBase[TTestType, TSelfRef]:
     normal: TTestType
     optional: Optional[TTestType]
@@ -36,3 +44,6 @@ ClassListDataClass = ClassBase[list[DataClass], "ClassListDataClass"]
 ClassDictDataClass = ClassBase[dict[str, DataClass], "ClassDictDataClass"]
 ClassLiteral = ClassBase[Literal["my-literal"], "ClassLiteral"]
 ClassMultiLiteral = ClassBase[Literal[2, 3, 5, 7, 11], "ClassMultiLiteral"]
+
+ClassGenericDataClassINT = ClassBase[GenericDataClass[int], "ClassGenericDataClassINT"]
+ClassGenericDataClassSubClass = ClassBase[GenericDataClassSubClass, "ClassGenericDataClassSubClass"]

--- a/tests/test_from_dict.py
+++ b/tests/test_from_dict.py
@@ -377,6 +377,17 @@ def test_parent_generic_dataclass():
     assert isinstance(v.field_3, str)
     assert isinstance(v.field_4, int)
 
+    @dataclass(frozen=True)
+    class TstClassMain2(TstClassMainParent[Data1, Data2]):
+        field_5: int
+
+    v = from_dict(TstClassMain2, field_1=dict(value=1), field_2={"value":"1"}, field_3="s", field_4=1, field_5=3, fd_check_types=True)
+    assert isinstance(v.field_1, Data1)
+    assert isinstance(v.field_2, Data2)
+    assert isinstance(v.field_3, str)
+    assert isinstance(v.field_4, int)
+    assert isinstance(v.field_5, int)
+
 
 def test_generic_norm_class():
     TParam1 = TypeVar('TParam1')

--- a/tests/test_type_checking.py
+++ b/tests/test_type_checking.py
@@ -15,18 +15,22 @@ import pytest
 if sys.version_info[0:1] < (3, 12):
     from _type_checking_classes import (
         NormalClass, DataClass, AttrClass,
+        GenericDataClass, GenericDataClassSubClass,
         ClassPrimitives, ClassDict, ClassDictSimple,
         ClassList, ClassDataClass, ClassNormalClass,
         ClassAttrClass, ClassListDataClass, ClassDictDataClass,
-        ClassLiteral, ClassMultiLiteral
+        ClassLiteral, ClassMultiLiteral,
+        ClassGenericDataClassINT, ClassGenericDataClassSubClass
     )
 else:
     from _type_checking_classes_py312 import (
         NormalClass, DataClass, AttrClass,
+        GenericDataClass, GenericDataClassSubClass,
         ClassPrimitives, ClassDict, ClassDictSimple,
         ClassList, ClassDataClass, ClassNormalClass,
         ClassAttrClass, ClassListDataClass, ClassDictDataClass,
-        ClassLiteral, ClassMultiLiteral
+        ClassLiteral, ClassMultiLiteral,
+        ClassGenericDataClassINT, ClassGenericDataClassSubClass
     )
 
 
@@ -90,6 +94,9 @@ class NormTestParams:
     pytest.param(NormTestParams(ClassLiteral, lambda: "my-literal", lambda: "my-literal"), id="literal-single"),
     pytest.param(NormTestParams(ClassMultiLiteral, lambda: 3, lambda: 3), id="literal-multi-1"),
     pytest.param(NormTestParams(ClassMultiLiteral, lambda: 11, lambda: 11), id="literal-multi-2"),
+
+    pytest.param(NormTestParams(ClassGenericDataClassINT, lambda: {"field": 1}, lambda: GenericDataClass[int](1)), id="generic-init"),
+    pytest.param(NormTestParams(ClassGenericDataClassSubClass, lambda: {"field": "1", "another": 2}, lambda: GenericDataClassSubClass("1", 2)), id="generic-sub"),
 ])
 def norm_params(request):
     yield request.param
@@ -117,6 +124,9 @@ class NegativeTestParams:
     pytest.param(NegativeTestParams(ClassLiteral, lambda: "my-literal", lambda: 1), id="literal-single"),
     pytest.param(NegativeTestParams(ClassMultiLiteral, lambda: 3, lambda: 1), id="literal-multi-1"),
     pytest.param(NegativeTestParams(ClassMultiLiteral, lambda: 5, lambda: 10), id="literal-multi-2"),
+    
+    pytest.param(NegativeTestParams(ClassGenericDataClassINT, lambda: {"field": 1}, lambda: 1), id="generic-init"),
+    pytest.param(NegativeTestParams(ClassGenericDataClassSubClass, lambda: {"field": "1", "another": 2}, lambda: 2), id="generic-sub"),
 ])
 def negative_params(request):
     yield request.param


### PR DESCRIPTION
When a class inherited from a generic class and defined its own `__init__`, the code was using the parent class's `__init__` to find the type hints.